### PR TITLE
Upgrade `standard` to `7.0.1` (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "loader-utils": "^0.2.12",
     "object-assign": "^4.0.1",
-    "standard": "^6.0.5"
+    "standard": "^7.0.1"
   },
   "directories": {
     "example": "example"


### PR DESCRIPTION
Upgrade `standard` to `7.0.1` (latest), to fix `TypeError: Path must be a string` issues on node `6.0.0`. Fixes #64
