### PR TITLE
Added the ability to emit error instead of warnings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,9 @@ const config = {
   },
   standard: {
     // config options to be passed through to standard e.g.
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
+    // Emit errors instead of warnings
+    emitErrors: true
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -35,11 +35,19 @@ module.exports = function standardLoader (text) {
     if (config.snazzy !== false) {
       snazzy({encoding: 'utf8'})
       .on('data', function (data) {
-        self.emitWarning(data)
+        if (config.emitErrors) {
+          self.emitError(data)
+        } else {
+          self.emitWarning(data)
+        }
       })
       .end(warnings)
     } else {
-      self.emitWarning(warnings)
+      if (config.emitErrors) {
+        self.emitError(warnings)
+      } else {
+        self.emitWarning(warnings)
+      }
     }
     callback(err, text)
   })

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ var webpack = require('webpack')
 var config = require('./fixtures/webpack.config')
 var assign = require('object-assign')
 
-test('logs error with snazzy', function (t) {
+test('logs warning with snazzy', function (t) {
   webpack(config, function (err, stats) {
     t.ifError(err)
     t.ok(stats.compilation.warnings.length, 'has warnings')
@@ -30,6 +30,17 @@ test('can disable snazzy output', function (t) {
     var warning = stats.compilation.warnings[0]
     t.ok(warning && /semicolon/gm.test(warning.warning), 'has warning about semicolon')
     t.equal(warning.warning.indexOf('\n\u001b'), -1, 'snazzy output disabled')
+    t.end()
+  })
+})
+
+test('logs error', function (t) {
+  config.standard.emitErrors = true
+  webpack(config, function (err, stats) {
+    t.ifError(err)
+    t.ok(stats.compilation.errors.length, 'has errors')
+    const error = stats.compilation.errors[0]
+    t.ok(error && /semicolon/gm.test(error.error), 'has error about semicolon')
     t.end()
   })
 })


### PR DESCRIPTION
This pull request adds a new configuration parameter at the webpack config ("emitErrors"), that opens the possibility to fail a webpack bundle if there are any compilation issue. It still have the possibility to emit warnings instead of errors, if you just omit the emitErrors config or set emitErrors = false.

This is useful to enforce an always linted application and avoid the "Let me fix that later", that we all say and sometimes forget to do =D

Ps: This is an adaptation (almost identical) of [this fork's commit](https://github.com/felix/standard-loader/commit/ffea8d4d54eb796c6e42a1595cde1cbb67147e44). All credits goes to him, i just adapted it to be compatible with the latest version of standard-loader