### PR TITLE
Exclude files matching ignore patterns (fixes #71)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,21 @@ var format = require('util').format
 var assign = require('object-assign')
 var loaderUtils = require('loader-utils')
 var snazzy = require('snazzy')
+var pkgConf = require('pkg-conf')
+var multimatch = require('multimatch')
 
 module.exports = function standardLoader (text) {
   var self = this
   var callback = this.async()
+  var loaderOpts = loaderUtils.getLoaderConfig(this, 'standard')
+  var packageOpts = pkgConf.sync('standard', { cwd: loaderOpts.cwd || process.cwd() })
+  var ignoredFile = !!multimatch(this.resourcePath, packageOpts.ignore).length
+
+  if (ignoredFile) return callback(null, text)
 
   var config = assign(
-    this.options.standard || {},
+    packageOpts,
+    loaderOpts,
     loaderUtils.parseQuery(this.query)
   )
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.15",
+    "multimatch": "^2.1.0",
     "object-assign": "^4.1.0",
     "snazzy": "^4.0.0"
   },

--- a/test/fixtures/ignore.js
+++ b/test/fixtures/ignore.js
@@ -1,0 +1,6 @@
+//code not conforming to standard style, but ignored
+
+module.exports = function(a,b) {
+    var file = 'ignored';
+    console.log( file);
+}

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,0 +1,7 @@
+{
+  "standard": {
+    "ignore": [
+      "**/ignore.js"
+    ]
+  }
+}

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 const config = {
   entry: {
     fail: path.join(__dirname, 'fail.js'),
+    ignore: path.join(__dirname, 'ignore.js'),
     pass: path.join(__dirname, 'pass.js')
   },
   output: {

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ var assign = require('object-assign')
 test('logs error with snazzy', function (t) {
   webpack(config, function (err, stats) {
     t.ifError(err)
+    t.ok(stats.compilation.warnings.length === 2)
     t.ok(stats.compilation.warnings.length, 'has warnings')
     t.ok(!stats.compilation.errors.length, 'has no errors')
     var warning = stats.compilation.warnings[0]
@@ -30,6 +31,22 @@ test('can disable snazzy output', function (t) {
     var warning = stats.compilation.warnings[0]
     t.ok(warning && /semicolon/gm.test(warning.warning), 'has warning about semicolon')
     t.equal(warning.warning.indexOf('\n\u001b'), -1, 'snazzy output disabled')
+    t.end()
+  })
+})
+
+test('excludes files matching ignore pattern', function (t) {
+  var preloader = assign({}, config.module.preLoaders[0], {
+    query: {
+      cwd: 'test/fixtures'
+    }
+  })
+
+  config.module.preLoaders[0] = preloader
+
+  webpack(config, function (err, stats) {
+    t.ifError(err)
+    t.ok(stats.compilation.warnings.length === 1)
     t.end()
   })
 })


### PR DESCRIPTION
Do not run the loader against file paths matching ignore patterns within the StandardJS [package config](https://github.com/feross/standard/tree/v10.0.0-beta.0#how-do-i-ignore-files).