### PR TITLE
Typo fix in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,9 +40,9 @@ const config = {
         exclude: /(node_modules|bower_components)/,
         options: {
           // Emit errors instead of warnings (default = false)
-          error: false
+          error: false,
           // enable snazzy output (default = true)
-          snazzy: true
+          snazzy: true,
           // other config options to be passed through to standard e.g.
           parser: 'babel-eslint'
         }


### PR DESCRIPTION
Thanks for your work!

I have a very very minor typo fix to submit : don't know if it was intended, but two commas are missing from the Webpack example.
I foolishly copy / pasted the example before realizing it, figure that it could happen to someone else too.