### PR TITLE
Added globals to the example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,8 @@ const config = {
         loader: 'standard-loader',
         exclude: /(node_modules|bower_components)/,
         options: {
+          // custom global variables to declare, e.g., $, jQuery, React, PropTypes
+          globals: [],
           // Emit errors instead of warnings (default = false)
           error: false,
           // enable snazzy output (default = true)


### PR DESCRIPTION
I added the `globals`  option to the example as it helped me play along with `webpack.ProvidePlugin`