### PR TITLE
Add support for other standard linters - RM always on req for 'standard'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,26 @@
 'use strict'
 
-var Standard = require('standard')
 var format = require('util').format
 var loaderUtils = require('loader-utils')
 var snazzy = require('snazzy')
 var assign = require('object-assign')
 
 module.exports = function standardLoader (input, map) {
+  let standard
   var webpack = this
   var callback = webpack.async()
   webpack.cacheable()
 
   var config = assign({}, loaderUtils.getOptions(webpack))
   config.filename = webpack.resourcePath
-  let standard = Standard
 
   // allow configurable 'standard' e.g. standardx
-  if (config.standard) {
-    if (typeof config.standard === 'string') {
-      standard = require(config.standard)
-    } else {
-      standard = config.standard
-    }
+  if (config.standard && typeof config.standard === 'string') {
+    standard = require(config.standard)
+  }
+  // IF standard is not defined after checking config standard, set standard require standard :-)
+  if (standard === undefined) {
+    standard = require('standard')
   }
 
   delete config.standard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-loader",
-  "version": "6.1.0-pre.0",
+  "version": "6.1.1",
   "description": "Lint webpack builds with standard/standard.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@timoxley For the record.... I'm a standard fella. But my boss... He loves the semicolons. So here we are. 

I could not use standard-loader as is because of the always on requirement of standard up top. Our system dictates linting rules based on the standard version it finds and if standard is included in the app semistandard will never get hit. 

By moving this require down to after the config.standard examination, those not using standard standard 😭will no longer be required to have it installed to use the loader. 

Can I get that merged up soon or feedbacked trying to put a lid on this build by EOW. Purrty Please and thank you. 